### PR TITLE
[Tech] handle chain not added gracefully in getChainMetadataSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/chains",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A package to get chain metadata",
   "main": "src/index.js",
   "author": "Brett Cleary",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,10 @@ export async function getChainMetadata(
 }
 
 export function getChainMetadataSync(chainId: string, params?: ChainMetadataParams): ChainMetadata | undefined{
-  return processMetadata(commonChains[chainId], params)
+  if (Object.hasOwn(commonChains, chainId)) {
+    return processMetadata(commonChains[chainId], params)
+  }
+  return undefined
 }
 
 export const chainMap = commonChains


### PR DESCRIPTION
If a chain were not added previously, metadata would be undefined in `processMetadata` which would then throw